### PR TITLE
Update export in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 import * as rpc from "./bootstrap/init-rpc";
 
-export default rpc.default;
+const rpcServer = rpc.default;
+
+export default {
+  rpcServer,
+};


### PR DESCRIPTION
This pull request updates the export in the `index.ts` file. Previously, the file exported the default value from `bootstrap/init-rpc`, but now it exports an object with a `rpcServer` property that holds the default value from `bootstrap/init-rpc`.