### PR TITLE
Add toJsonSequelize helper function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amqplib-kit-microservice",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amqplib-kit-microservice",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-kit-microservice",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Kit de desenvolvimento de integrações com microsserviços",
   "main": "src/index.ts",
   "scripts": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,3 @@
+import toJsonSequelize from "./shared/helpers/sequelize/to-json.sequelize";
+
+export { toJsonSequelize };


### PR DESCRIPTION
This pull request adds a new helper function called `toJsonSequelize` to the `helpers.ts` file. This function assists with converting Sequelize models to JSON format. Additionally, the version of the `amqplib-kit-microservice` package has been updated from `0.3.2` to `0.4.0` in the `package.json` file.