### PR TITLE
Refactor import paths in load-prompts.ts and handler-request.ts

### DIFF
--- a/src/bootstrap/load-prompts.ts
+++ b/src/bootstrap/load-prompts.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { Prompts } from "src/shared/handlers/handler-request";
+import { Prompts } from "src/types/handler-types";
 
 export function loadPrompts(promptsDir: string): Prompts {
   const prompts = fs.readdirSync(promptsDir).map((file) => {

--- a/src/shared/handlers/handler-request.ts
+++ b/src/shared/handlers/handler-request.ts
@@ -1,6 +1,6 @@
 // handler must return always a json object
-export type HandlerType = (message?: string) => Promise<string>;
-export type Prompts = { name: string; handler: HandlerType }[];
+import { Prompts } from "src/types/handler-types";
+import { HandlerType } from "src/types/handler-types";
 
 export default async function handleRequest(
   prompts: Prompts,

--- a/src/types/handler-types.ts
+++ b/src/types/handler-types.ts
@@ -1,0 +1,2 @@
+export type HandlerType = (message?: string) => Promise<string>;
+export type Prompts = { name: string; handler: HandlerType }[];


### PR DESCRIPTION
This pull request refactors the import paths in the `load-prompts.ts` and `handler-request.ts` files. The import paths have been updated to use the correct paths from the `src/types/handler-types` module. This ensures that the code is using the correct types and improves the overall organization of the codebase.